### PR TITLE
Add Ingredients Information Data

### DIFF
--- a/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/DetailsRecipeActivity.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/DetailsRecipeActivity.kt
@@ -12,6 +12,7 @@ import com.sandoval.recipesapp.ui.details_recipes.adapter.ViewPagerDetailRecipes
 import com.sandoval.recipesapp.ui.details_recipes.fragments.IngredientsFragment
 import com.sandoval.recipesapp.ui.details_recipes.fragments.InstructionsFragment
 import com.sandoval.recipesapp.ui.details_recipes.fragments.OverViewFragment
+import com.sandoval.recipesapp.utils.Constants.Companion.RECIPE_RESULT_KEY
 
 class DetailsRecipeActivity : AppCompatActivity() {
 
@@ -45,7 +46,7 @@ class DetailsRecipeActivity : AppCompatActivity() {
         titles.add("Instructions")
 
         val resultBundle = Bundle()
-        resultBundle.putParcelable("recipeBundle", args.result)
+        resultBundle.putParcelable(RECIPE_RESULT_KEY, args.result)
 
         val pagerAdapter = ViewPagerDetailRecipesAdapter(
             resultBundle, fragments, titles, supportFragmentManager

--- a/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/adapter/IngredientsAdapter.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/adapter/IngredientsAdapter.kt
@@ -1,0 +1,65 @@
+package com.sandoval.recipesapp.ui.details_recipes.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.sandoval.recipesapp.R
+import com.sandoval.recipesapp.data.models.ExtendedIngredient
+import com.sandoval.recipesapp.databinding.IngredientsRowLayoutBinding
+import com.sandoval.recipesapp.utils.Constants.Companion.BASE_IMAGE_URL
+import com.sandoval.recipesapp.utils.RecipesDiffUtil
+import java.util.*
+
+class IngredientsAdapter :
+    RecyclerView.Adapter<IngredientsAdapter.MyViewHolder>() {
+
+    private var ingredientsList = emptyList<ExtendedIngredient>()
+
+    class MyViewHolder(val binding: IngredientsRowLayoutBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup, viewType: Int
+    ): MyViewHolder {
+        return MyViewHolder(
+            IngredientsRowLayoutBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
+        holder.binding.ingredientImageView.load(BASE_IMAGE_URL + ingredientsList[position].image) {
+            crossfade(600)
+            error(R.drawable.ic_error_placeholder)
+        }
+        holder.binding.ingredientName.text =
+            ingredientsList[position].name.replaceFirstChar {
+                if (it.isLowerCase()) it.titlecase(
+                    Locale.ROOT
+                ) else it.toString()
+            }
+        holder.binding.ingredientAmount.text =
+            ingredientsList[position].amount.toString()
+        holder.binding.ingredientUnit.text = ingredientsList[position].unit
+        holder.binding.ingredientConsistency.text =
+            ingredientsList[position].consistency
+        holder.binding.ingredientOriginal.text =
+            ingredientsList[position].original
+    }
+
+    override fun getItemCount(): Int {
+        return ingredientsList.size
+    }
+
+    fun setData(newIngredients: List<ExtendedIngredient>) {
+        val ingredientsDiffUtil =
+            RecipesDiffUtil(ingredientsList, newIngredients)
+        val diffUtilResult = DiffUtil.calculateDiff(ingredientsDiffUtil)
+        ingredientsList = newIngredients
+        diffUtilResult.dispatchUpdatesTo(this)
+    }
+
+}

--- a/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/fragments/IngredientsFragment.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/fragments/IngredientsFragment.kt
@@ -1,19 +1,50 @@
 package com.sandoval.recipesapp.ui.details_recipes.fragments
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.sandoval.recipesapp.R
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.sandoval.recipesapp.databinding.FragmentIngredientsBinding
+import com.sandoval.recipesapp.ui.details_recipes.adapter.IngredientsAdapter
+import com.sandoval.recipesapp.utils.Constants.Companion.RECIPE_RESULT_KEY
+import com.sandoval.recipesapp.data.models.Result
+import com.sandoval.recipesapp.utils.retrieveParcelable
 
 class IngredientsFragment : Fragment() {
 
+    private val mAdapter: IngredientsAdapter by lazy { IngredientsAdapter() }
+
+    private var _binding: FragmentIngredientsBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_ingredients, container, false)
+        _binding =
+            FragmentIngredientsBinding.inflate(inflater, container, false)
+
+        val args = arguments
+        val myBundle: Result? = args?.retrieveParcelable(RECIPE_RESULT_KEY)
+
+        setupRecyclerView()
+        myBundle?.extendedIngredients?.let { mAdapter.setData(it) }
+
+        return binding.root
+    }
+
+    private fun setupRecyclerView() {
+        binding.ingredientsRecyclerView.adapter = mAdapter
+        binding.ingredientsRecyclerView.layoutManager =
+            LinearLayoutManager(requireContext())
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/fragments/OverViewFragment.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/ui/details_recipes/fragments/OverViewFragment.kt
@@ -10,6 +10,7 @@ import coil.load
 import com.sandoval.recipesapp.R
 import com.sandoval.recipesapp.databinding.FragmentOverViewBinding
 import com.sandoval.recipesapp.data.models.Result
+import com.sandoval.recipesapp.utils.Constants.Companion.RECIPE_RESULT_KEY
 import org.jsoup.Jsoup
 
 class OverViewFragment : Fragment() {
@@ -28,7 +29,7 @@ class OverViewFragment : Fragment() {
 
         val args = arguments
 
-        val myBundle: Result? = args?.getParcelable("recipeBundle")
+        val myBundle: Result? = args?.getParcelable(RECIPE_RESULT_KEY)
 
         fragmentOverViewBinding.recipeImgView.load(myBundle?.image)
         fragmentOverViewBinding.recipeDetailTitleText.text = myBundle?.title

--- a/app/src/main/java/com/sandoval/recipesapp/utils/Constants.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/utils/Constants.kt
@@ -5,6 +5,8 @@ class Constants {
     companion object {
         const val BASE_URL = "https://api.spoonacular.com"
         const val API_KEY = "4b22b94da3b845059a86d6899dd29b32"//4b22b94da3b845059a86d6899dd29b32
+        const val BASE_IMAGE_URL = "https://spoonacular.com/cdn/ingredients_100x100/"
+        const val RECIPE_RESULT_KEY = "recipeBundle"
 
         // API Query Keys
         const val QUERY_SEARCH = "query"

--- a/app/src/main/java/com/sandoval/recipesapp/utils/RecipeExtensionFunctions.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/utils/RecipeExtensionFunctions.kt
@@ -3,6 +3,9 @@ package com.sandoval.recipesapp.utils
 import android.app.Activity
 import android.content.Context
 import android.graphics.Rect
+import android.os.Build.VERSION.SDK_INT
+import android.os.Bundle
+import android.os.Parcelable
 import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -32,4 +35,9 @@ fun Activity.hideKeyboard() {
 fun Context.hideKeyboard(view: View) {
     val inputMethodManager = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+}
+
+inline fun <reified T : Parcelable> Bundle.retrieveParcelable(key: String): T? = when {
+    SDK_INT >= 33 -> getParcelable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
 }

--- a/app/src/main/java/com/sandoval/recipesapp/utils/RecipesDiffUtil.kt
+++ b/app/src/main/java/com/sandoval/recipesapp/utils/RecipesDiffUtil.kt
@@ -1,30 +1,26 @@
 package com.sandoval.recipesapp.utils
 
 import androidx.recyclerview.widget.DiffUtil
-import com.sandoval.recipesapp.data.models.Result
 
-class RecipesDiffUtil(
-    private val oldList: List<Result>, private val newList: List<Result>
+class RecipesDiffUtil<T>(
+    private val oldRecipes: List<T>,
+    private val newRecipes: List<T>
 ) : DiffUtil.Callback() {
+
+
     override fun getOldListSize(): Int {
-        return oldList.size
+        return oldRecipes.size
     }
 
     override fun getNewListSize(): Int {
-        return newList.size
+        return newRecipes.size
     }
 
-    override fun areItemsTheSame(
-        oldItemPosition: Int, newItemPosition: Int
-    ): Boolean {
-        return oldList[oldItemPosition] == newList[newItemPosition]
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldRecipes[oldItemPosition] === newRecipes[newItemPosition]
     }
 
-    override fun areContentsTheSame(
-        oldItemPosition: Int, newItemPosition: Int
-    ): Boolean {
-        return oldList[oldItemPosition] == newList[newItemPosition]
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldRecipes[oldItemPosition] == newRecipes[newItemPosition]
     }
-
-
 }

--- a/app/src/main/res/drawable/ic_error_placeholder.xml
+++ b/app/src/main/res/drawable/ic_error_placeholder.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:pathData="M10,0L190,0A10,10 0,0 1,200 10L200,190A10,10 0,0 1,190 200L10,200A10,10 0,0 1,0 190L0,10A10,10 0,0 1,10 0z"
+        android:fillColor="#fff"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M66.499,72 L100.999,131L31.999,131Z"
+        android:strokeAlpha="0.1"
+        android:fillAlpha="0.1"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M119.999,49 L167.999,131L71.999,131Z"
+        android:strokeAlpha="0.1"
+        android:fillAlpha="0.1"/>
+</vector>

--- a/app/src/main/res/layout/fragment_ingredients.xml
+++ b/app/src/main/res/layout/fragment_ingredients.xml
@@ -1,14 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.details_recipes.fragments.IngredientsFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        tools:context=".ui.details_recipes.fragments.IngredientsFragment">
 
-</FrameLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/ingredientsRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/ingredients_row_layout" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/ingredients_row_layout.xml
+++ b/app/src/main/res/layout/ingredients_row_layout.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="4dp">
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/ingredients_cardView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="10dp"
+            app:strokeColor="@color/strokeColor"
+            app:strokeWidth="1dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/ingredient_background"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:elevation="2dp"
+                android:background="@color/cardBackgroundColor">
+
+                <View
+                    android:id="@+id/white_background"
+                    android:layout_width="120dp"
+                    android:layout_height="0dp"
+                    android:background="@color/white"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/ingredient_imageView"
+                    android:layout_width="100dp"
+                    android:layout_height="100dp"
+                    app:layout_constraintStart_toStartOf="@+id/white_background"
+                    app:layout_constraintEnd_toEndOf="@+id/white_background"
+                    app:layout_constraintTop_toTopOf="@+id/white_background"
+                    app:layout_constraintBottom_toBottomOf="@+id/white_background"
+                    tools:srcCompat="@tools:sample/avatars" />
+
+                <TextView
+                    android:id="@+id/ingredient_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="12dp"
+                    tools:text="Name"
+                    android:fontFamily="@font/alata"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/titleColor"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/white_background"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/ingredient_amount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    tools:text="100"
+                    app:layout_constraintStart_toStartOf="@+id/ingredient_name"
+                    app:layout_constraintTop_toBottomOf="@+id/ingredient_name" />
+
+                <TextView
+                    android:id="@+id/ingredient_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    tools:text="Grams"
+                    app:layout_constraintBottom_toBottomOf="@+id/ingredient_amount"
+                    app:layout_constraintStart_toEndOf="@+id/ingredient_amount"
+                    app:layout_constraintTop_toTopOf="@+id/ingredient_amount" />
+
+                <TextView
+                    android:id="@+id/ingredient_consistency"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="12dp"
+                    tools:text="Consistency"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/ingredient_amount"
+                    app:layout_constraintTop_toBottomOf="@+id/ingredient_amount" />
+
+                <TextView
+                    android:id="@+id/ingredient_original"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="12dp"
+                    android:layout_marginBottom="12dp"
+                    tools:text="Original"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/ingredient_consistency"
+                    app:layout_constraintTop_toBottomOf="@+id/ingredient_consistency"
+                    app:layout_constraintVertical_bias="0.0" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,4 +24,11 @@
     <color name="uncheckedChipTextColor">@color/darkGray</color>
 
     <color name="actionBarBackgroundColor">@color/colorPrimary</color>
+
+    <!--Custom Ingredients Colors-->
+    <color name="strokeColor">@color/lightMediumGray</color>
+    <color name="cardBackgroundColor">@color/white</color>
+    <color name="cardBackgroundLightColor">#106200EA</color>
+    <color name="titleColor">@color/darker</color>
+    <color name="descriptionColor">@color/darkGray</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,4 +59,6 @@
     <string name="overview_fragment_dairy_free_imageview_desc">Dairy Free Imageview Desc</string>
     <string name="overview_fragment_healthy_imageview_desc">Healthy Imageview Desc</string>
     <string name="overview_fragment_cheap_imageview_desc">Cheap Imageview desc</string>
+
+    <string name="ingredient_fragment_ingredient_imageview_desc">Ingredient content desc</string>
 </resources>


### PR DESCRIPTION
- Create the ingredients adapter to pass the information of the extended ingredients model class
- Add to the constants the recipe bundle key and the base image url for the ingredients image
- Refactor details activity to pass the recipe bundle key instead of hardcoded key string
- Refactor the overview fragment to get from the bundle the recipe bundle key instead of a hardcoded key string
- Create in the extension functions a retrieveParcelable method to check the SDK version so will be able to switch through the right implementation to get the parcelable key
- Refactor the DiffUtil class to be a Generic class so it can be usable through the project in all the adapters that need to check this callback
- Pass the ingredients fragment and the ingredients row to databinding implementation so they can be used normally in the adapters and in the fragments
- Add some new colors and strings for the ingredients part
- Setup the ingredients fragment to use the ingredients adapters and to be filled with the data through the databinding methods